### PR TITLE
Example docs change, skipping CI via changelog

### DIFF
--- a/changelog/v1.0.1/first-changelog.yaml
+++ b/changelog/v1.0.1/first-changelog.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update some docs
+    skipCI: true

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 # Testing GitHub Actions
 
 Testbed repo for trying out skipping GitHub Actions on required checks
+
+Skipping CI is accomplished by adding `skipCI: true` to the changelog YAML.


### PR DESCRIPTION
Example of a risk-free Docs-only PR that should be able to skip the length CI process.